### PR TITLE
fix: "/index.css" não é um arquivo existente

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,6 +1,5 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import './index.css'
 import App from './App.jsx'
 
 createRoot(document.getElementById('root')).render(


### PR DESCRIPTION
O trecho:
```
import './index.css'
```
não era um caminho existente e estava quebrando a página principal.